### PR TITLE
Fix operators visibility in Bow Lite umbrella module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,25 +6,24 @@ let package = Package(
     name: "BowLite",
 
     products: [
-        .library(name: "BowLite", targets: [Target.bowLite.name]),
+        .library(name: "BowLite", targets: [Target.lite.name]),
     ],
 
     dependencies: [
         .package(url: "https://github.com/bow-swift/SwiftCheck.git", from: "0.12.1"),
     ],
 
-    targets: [
-        Target.libraries,
-        Target.tests,
-    ].flatMap { $0 }
+    targets: Target.all
 )
 
 
 // MARK: - Libraries
 extension Target {
-    static var libraries: [Target] {
+    static var all: [Target] = sources + tests
+    
+    static var sources: [Target] {
         [
-            .bowLite,
+            .lite,
             .core,
             .effects,
             .optics
@@ -37,25 +36,32 @@ extension Target {
 
     static var effects: Target {
         #if os(Linux)
-        return .target(name: "BowLiteEffects",
-                       dependencies: [.target(name: Target.core.name)],
-                       exclude: ["Effects/Foundation/FileManager+iOS+Mac.swift"])
+        return .target(
+            name: "BowLiteEffects",
+            dependencies: [.target(name: Target.core.name)],
+            exclude: ["Effects/Foundation/FileManager+iOS+Mac.swift"])
         #else
-        return .target(name: "BowLiteEffects",
-                       dependencies: [.target(name: Target.core.name)])
+        return .target(
+            name: "BowLiteEffects",
+            dependencies: [.target(name: Target.core.name)])
         #endif
     }
 
     static var optics: Target {
-        .target(name: "BowLiteOptics",
-                dependencies: [.target(name: Target.core.name)])
+        .target(
+            name: "BowLiteOptics",
+            dependencies: [.target(name: Target.core.name)])
     }
 
-    static var bowLite: Target {
-        .target(name: "BowLite",
-                dependencies: [.target(name: Target.core.name),
-                               .target(name: Target.effects.name),
-                               .target(name: Target.optics.name)])
+    static var lite: Target {
+        .target(
+            name: "BowLite",
+            dependencies: [
+                .target(name: Target.core.name),
+                .target(name: Target.effects.name),
+                .target(name: Target.optics.name)
+            ]
+        )
     }
 }
 
@@ -63,7 +69,7 @@ extension Target {
 extension Target {
     static var tests: [Target] {
         [
-            .bowLiteLaws,
+            .laws,
             .coreTests,
             .effectsTests
         ]
@@ -72,21 +78,31 @@ extension Target {
     static var coreTests: Target {
         .testTarget(
             name: "BowLiteCoreTests",
-            dependencies: [.target(name: Target.core.name),
-                           .target(name: Target.bowLiteLaws.name)])
+            dependencies: [
+                .target(name: Target.core.name),
+                .target(name: Target.laws.name)
+            ]
+        )
     }
 
     static var effectsTests: Target {
-        .testTarget(name: "BowLiteEffectsTests",
-                    dependencies: [.target(name: Target.effects.name),
-                                   .target(name: Target.bowLiteLaws.name)])
+        .testTarget(
+            name: "BowLiteEffectsTests",
+            dependencies: [
+                .target(name: Target.effects.name),
+                .target(name: Target.laws.name)
+            ]
+        )
     }
 
-    static var bowLiteLaws: Target {
-        .testTarget(
+    static var laws: Target {
+        .target(
             name: "BowLiteLaws",
-            dependencies: [.target(name: Target.core.name),
-                           .target(name: Target.effects.name),
-                           .product(name: "SwiftCheck", package: "SwiftCheck")])
+            dependencies: [
+                .target(name: Target.core.name),
+                .target(name: Target.effects.name),
+                .product(name: "SwiftCheck", package: "SwiftCheck")
+            ],
+            path: "Tests/BowLiteLaws")
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ extension Target {
         return .target(
             name: "BowLiteEffects",
             dependencies: [.target(name: Target.core.name)],
-            exclude: ["Effects/Foundation/FileManager+iOS+Mac.swift"])
+            exclude: ["Foundation/FileManager+iOS+Mac.swift"])
         #else
         return .target(
             name: "BowLiteEffects",

--- a/Sources/BowLite/Headers.swift
+++ b/Sources/BowLite/Headers.swift
@@ -1,3 +1,27 @@
 @_exported import BowLiteCore
 @_exported import BowLiteEffects
 @_exported import BowLiteOptics
+
+precedencegroup KleisliCompositionPrecedence {
+    associativity: left
+}
+
+infix operator >=>: KleisliCompositionPrecedence
+
+precedencegroup CompositionPrecedence {
+    associativity: left
+}
+
+infix operator <<<: CompositionPrecedence
+infix operator >>>: CompositionPrecedence
+
+precedencegroup PartialApplicationPrecedence {}
+
+infix operator |> : PartialApplicationPrecedence
+
+infix operator <- : AssignmentPrecedence
+prefix operator |<-
+
+// Using operator / to obtain prisms, as seen on
+// Pointfree's Case Paths: https://github.com/pointfreeco/swift-case-paths
+prefix operator /


### PR DESCRIPTION
## Related issues

- When grouping targets in our `BowLite` umbrella module, it seems the experimental `@_exported` is not properly exposing the custom operators that we have defined in the inner modules.
- There was a problem running the tests due to a misconfiguration of the laws module.

## Implementation details

Custom operators had to be copied to a file in the umbrella module to make them visible from the outside, together with their custom precedence groups.